### PR TITLE
Remove Length Limitation of the Email and Password Field

### DIFF
--- a/src/main/java/the_fireplace/ias/gui/AbstractAccountGui.java
+++ b/src/main/java/the_fireplace/ias/gui/AbstractAccountGui.java
@@ -38,9 +38,7 @@ public abstract class AbstractAccountGui extends GuiScreen
 		this.buttonList.add(new GuiButton(3, this.width / 2 + 2, this.height - 28, 150, 20, I18n.format("gui.cancel")));
 		username = new GuiTextField(0, this.fontRenderer, this.width / 2 - 100, 60, 200, 20);
 		username.setFocused(true);
-		username.setMaxStringLength(64);
 		password = new GuiPasswordField(1, this.fontRenderer, this.width / 2 - 100, 90, 200, 20);
-		password.setMaxStringLength(64);
 		complete.enabled = false;
 	}
 


### PR DESCRIPTION
The email and password should not be limited to 64 characters as someone could have a email or password that is longer than 64 characters.